### PR TITLE
Add youtube filament filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,10 +171,11 @@
         <!-- Other Filters -->
           <div class="filter-group">
           <div class="filter-header" data-target="other-options">
-            <span class="filter-label">Other <span class="filter-count" id="other-count">(2)</span></span>
+            <span class="filter-label">Other <span class="filter-count" id="other-count">(3)</span></span>
             <span class="filter-toggle">▼</span>
           </div>
           <div class="filter-options" id="other-options">
+            <label><input type="checkbox" id="flag-youtube-only">From YouTube Video</label>
             <label><input type="checkbox" id="flag-professional-only">Professional/Advanced Equipment</label>
             <label><input type="checkbox" id="flag-popular-materials">Popular Materials</label>
           </div>


### PR DESCRIPTION
Add 'From YouTube Video' filter to show only filaments featured in the embedded YouTube video dataset.

---
<a href="https://cursor.com/background-agent?bcId=bc-d84c801a-e9a7-479e-a758-2980a576e3bf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d84c801a-e9a7-479e-a758-2980a576e3bf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

